### PR TITLE
Add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,33 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, opened, edited, ready_for_review, reopened]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  status: {}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Auto merge if labeled
+        uses: pascalgn/merge-action@v0.15.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_LABELS: "auto-merge,!work in progress,!do not merge"
+          MERGE_METHOD: "squash"
+          MERGE_DELETE_BRANCH: "true"
+          MERGE_RETRIES: "6"
+          MERGE_RETRY_SLEEP: "10000"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "merge"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for auto-merging PRs with 'auto-merge' label

## Details
This workflow will enable automatic merging of pull requests that:
- Have the 'auto-merge' label
- Pass all required checks
- Are not in draft state
- Don't have blocking labels like 'work in progress' or 'do not merge'

This is needed to enable the auto-merge functionality for PR #59.

🤖 Generated with [Claude Code](https://claude.ai/code)